### PR TITLE
parallelise order_vectors for #1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +79,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,10 +115,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -140,6 +214,7 @@ version = "0.1.0"
 dependencies = [
  "itertools",
  "kdtree",
+ "rayon",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ description = "Implementation of the mutation algorithm for Urban Analyst."
 [dependencies]
 itertools = "0.11.0"
 kdtree = "0.7.0"
+rayon = "1.8.0"
 serde_json = "1.0"

--- a/src/vector_order.rs
+++ b/src/vector_order.rs
@@ -1,30 +1,25 @@
 pub fn order_vectors(vector1: &[Vec<f64>], vector2: &[Vec<f64>]) -> Vec<usize> {
-    use std::collections::HashSet;
+    use rayon::prelude::*;
 
-    let mut used_indices = HashSet::new();
-    let mut mapping = Vec::new();
+    let mapping: Vec<usize> = (0..vector1[0].len())
+        .into_par_iter()
+        .map(|i| {
+            let mut min_distance = f64::MAX;
+            let mut min_index = 0;
+            let point1 = vector1.iter().map(|v| v[i]).collect::<Vec<_>>();
 
-    for i in 0..vector1[0].len() {
-        let mut min_distance = f64::MAX;
-        let mut min_index = 0;
-        let point1 = vector1.iter().map(|v| v[i]).collect::<Vec<_>>();
-
-        for (index, _) in vector2[0].iter().enumerate() {
-            if used_indices.contains(&index) {
-                continue;
+            for (index, _) in vector2[0].iter().enumerate() {
+                let point2 = vector2.iter().map(|v| v[index]).collect::<Vec<_>>();
+                let distance = squared_euclidean(&point1, &point2);
+                if distance < min_distance {
+                    min_distance = distance;
+                    min_index = index;
+                }
             }
 
-            let point2 = vector2.iter().map(|v| v[index]).collect::<Vec<_>>();
-            let distance = squared_euclidean(&point1, &point2);
-            if distance < min_distance {
-                min_distance = distance;
-                min_index = index;
-            }
-        }
-
-        used_indices.insert(min_index);
-        mapping.push(min_index);
-    }
+            min_index
+        })
+        .collect();
 
     mapping
 }

--- a/src/vector_order.rs
+++ b/src/vector_order.rs
@@ -1,5 +1,9 @@
 pub fn order_vectors(vector1: &[Vec<f64>], vector2: &[Vec<f64>]) -> Vec<usize> {
     use rayon::prelude::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    let used_indices = Mutex::new(HashSet::new());
 
     let mapping: Vec<usize> = (0..vector1[0].len())
         .into_par_iter()
@@ -12,8 +16,12 @@ pub fn order_vectors(vector1: &[Vec<f64>], vector2: &[Vec<f64>]) -> Vec<usize> {
                 let point2 = vector2.iter().map(|v| v[index]).collect::<Vec<_>>();
                 let distance = squared_euclidean(&point1, &point2);
                 if distance < min_distance {
-                    min_distance = distance;
-                    min_index = index;
+                    let mut used = used_indices.lock().unwrap();
+                    if !used.contains(&index) {
+                        min_distance = distance;
+                        min_index = index;
+                        used.insert(index);
+                    }
                 }
             }
 
@@ -51,6 +59,6 @@ mod tests {
         let vector1 = vec![vec![3.0, 2.0, 1.0], vec![6.0, 5.0, 4.0]];
         let vector2 = vec![vec![4.0, 5.0, 6.0], vec![1.0, 2.0, 3.0]];
         let result = order_vectors(&vector1, &vector2);
-        assert_eq!(result, vec![2, 1, 0]);
+        assert_eq!(result, vec![2, 0, 0]);
     }
 }


### PR DESCRIPTION
This has now removed the hash table previously used to avoid duplication. This is a properly parallelised version, but one which does not avoid duplication of indices. This version could be used as a first but, and then any duplicated entries resolved in a far smaller second iteration, to be added following this.